### PR TITLE
 Remove stray semicolon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<Error>> {
         )?;
     };
 
-    writeln!(&mut all_profiles, r#"];"#, )?;
+    writeln!(&mut all_profiles, r#"]"#, )?;
 
     Ok(())
 }


### PR DESCRIPTION
This semicolon is currently silently ignored, but we may be changing that in the future.

cc rust-lang/rust#64284